### PR TITLE
Correct CLI check for number of arguments

### DIFF
--- a/3mfthumb.cpp
+++ b/3mfthumb.cpp
@@ -24,7 +24,7 @@
 #include <lib3mf_implicit.hpp>
 
 int main(int argc, char **argv) {
-  if (argc < 2){
+  if (argc < 3){
     std::cout << "Usage: 3mfthumb <file.3mf> <output.png>" << std::endl;
     return 1;
   }


### PR DESCRIPTION
Found a small silly bug.  Hope this helps.
The program crashed if given exactly 1 argument because of out-of-bounds access to argv.  argc should be checked against less-than 3 when expecting 2 arguments.
